### PR TITLE
Bump `go.nhat.io/testcontainers-extra` to `v0.11.0`

### DIFF
--- a/elasticsearch/go.mod
+++ b/elasticsearch/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/docker/docker v23.0.6+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/stretchr/testify v1.8.2
-	go.nhat.io/testcontainers-extra v0.10.0
+	go.nhat.io/testcontainers-extra v0.11.0
 )
 
 require (

--- a/elasticsearch/go.sum
+++ b/elasticsearch/go.sum
@@ -75,8 +75,8 @@ github.com/testcontainers/testcontainers-go v0.20.1 h1:mK15UPJ8c5P+NsQKmkqzs/jMd
 github.com/testcontainers/testcontainers-go v0.20.1/go.mod h1:zb+NOlCQBkZ7RQp4QI+YMIHyO2CQ/qsXzNF5eLJ24SY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.nhat.io/testcontainers-extra v0.10.0 h1:q+31CR5qr3o9kIoa+/OS+K3eKlRk/gZKT+FXlR5WSi0=
-go.nhat.io/testcontainers-extra v0.10.0/go.mod h1:FuvyYRg1OTYbNM9fqfq6RwBEYS14/t0vPo8uDonasNs=
+go.nhat.io/testcontainers-extra v0.11.0 h1:G7OvKyC8tsloR2mJ/t/ZdgYwcf7WcJ2u72+Jgicau8c=
+go.nhat.io/testcontainers-extra v0.11.0/go.mod h1:YUKNSvEerBtzYSPnCdC+IJcJ9vDYd5Ww8Ge/Ikt/jCA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/mongo/go.mod
+++ b/mongo/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/stretchr/testify v1.8.2
 	go.mongodb.org/mongo-driver v1.11.6
-	go.nhat.io/testcontainers-extra v0.10.0
-	go.nhat.io/testcontainers-registry v0.12.0
+	go.nhat.io/testcontainers-extra v0.11.0
+	go.nhat.io/testcontainers-registry v0.13.0
 )
 
 require (

--- a/mongo/go.sum
+++ b/mongo/go.sum
@@ -1132,10 +1132,10 @@ go.mongodb.org/mongo-driver v1.7.0/go.mod h1:Q4oFMbo1+MSNqICAdYMlC/zSTrwCogR4R8N
 go.mongodb.org/mongo-driver v1.11.6 h1:XM7G6PjiGAO5betLF13BIa5TlLUUE3uJ/2Ox3Lz1K+o=
 go.mongodb.org/mongo-driver v1.11.6/go.mod h1:G9TgswdsWjX4tmDA5zfs2+6AEPpYJwqblyjsfuh8oXY=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
-go.nhat.io/testcontainers-extra v0.10.0 h1:q+31CR5qr3o9kIoa+/OS+K3eKlRk/gZKT+FXlR5WSi0=
-go.nhat.io/testcontainers-extra v0.10.0/go.mod h1:FuvyYRg1OTYbNM9fqfq6RwBEYS14/t0vPo8uDonasNs=
-go.nhat.io/testcontainers-registry v0.12.0 h1:HteE/bqtayK2Hj1yUtD7HnrAoY/AE3NRlsGDFYaVKUM=
-go.nhat.io/testcontainers-registry v0.12.0/go.mod h1:hyXHu+zaYJZGK9u3itEA172SroknZWMTuJOgSn5oLSc=
+go.nhat.io/testcontainers-extra v0.11.0 h1:G7OvKyC8tsloR2mJ/t/ZdgYwcf7WcJ2u72+Jgicau8c=
+go.nhat.io/testcontainers-extra v0.11.0/go.mod h1:YUKNSvEerBtzYSPnCdC+IJcJ9vDYd5Ww8Ge/Ikt/jCA=
+go.nhat.io/testcontainers-registry v0.13.0 h1:lrCgEwsCpWzroCyPPnTNAqnrnRlcIdBUB+pAzljZnpw=
+go.nhat.io/testcontainers-registry v0.13.0/go.mod h1:U4DdP3LAZ26cvwIEqzgGNV6PR3uSldR3jC0q3ViEUGI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/mssql/go.mod
+++ b/mssql/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/stretchr/testify v1.8.2
 	github.com/testcontainers/testcontainers-go v0.20.1
-	go.nhat.io/testcontainers-extra v0.10.0
-	go.nhat.io/testcontainers-registry v0.12.0
+	go.nhat.io/testcontainers-extra v0.11.0
+	go.nhat.io/testcontainers-registry v0.13.0
 )
 
 require (

--- a/mssql/go.sum
+++ b/mssql/go.sum
@@ -1139,10 +1139,10 @@ go.etcd.io/etcd/raft/v3 v3.5.0/go.mod h1:UFOHSIvO/nKwd4lhkwabrTD3cqW5yVyYYf/KlD0
 go.etcd.io/etcd/server/v3 v3.5.0/go.mod h1:3Ah5ruV+M+7RZr0+Y/5mNLwC+eQlni+mQmOVdCRJoS4=
 go.mongodb.org/mongo-driver v1.7.0/go.mod h1:Q4oFMbo1+MSNqICAdYMlC/zSTrwCogR4R8NzkI+yfU8=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
-go.nhat.io/testcontainers-extra v0.10.0 h1:q+31CR5qr3o9kIoa+/OS+K3eKlRk/gZKT+FXlR5WSi0=
-go.nhat.io/testcontainers-extra v0.10.0/go.mod h1:FuvyYRg1OTYbNM9fqfq6RwBEYS14/t0vPo8uDonasNs=
-go.nhat.io/testcontainers-registry v0.12.0 h1:HteE/bqtayK2Hj1yUtD7HnrAoY/AE3NRlsGDFYaVKUM=
-go.nhat.io/testcontainers-registry v0.12.0/go.mod h1:hyXHu+zaYJZGK9u3itEA172SroknZWMTuJOgSn5oLSc=
+go.nhat.io/testcontainers-extra v0.11.0 h1:G7OvKyC8tsloR2mJ/t/ZdgYwcf7WcJ2u72+Jgicau8c=
+go.nhat.io/testcontainers-extra v0.11.0/go.mod h1:YUKNSvEerBtzYSPnCdC+IJcJ9vDYd5Ww8Ge/Ikt/jCA=
+go.nhat.io/testcontainers-registry v0.13.0 h1:lrCgEwsCpWzroCyPPnTNAqnrnRlcIdBUB+pAzljZnpw=
+go.nhat.io/testcontainers-registry v0.13.0/go.mod h1:U4DdP3LAZ26cvwIEqzgGNV6PR3uSldR3jC0q3ViEUGI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/mysql/go.mod
+++ b/mysql/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/stretchr/testify v1.8.2
 	github.com/testcontainers/testcontainers-go v0.20.1
-	go.nhat.io/testcontainers-extra v0.10.0
-	go.nhat.io/testcontainers-registry v0.12.0
+	go.nhat.io/testcontainers-extra v0.11.0
+	go.nhat.io/testcontainers-registry v0.13.0
 )
 
 require (

--- a/mysql/go.sum
+++ b/mysql/go.sum
@@ -1118,10 +1118,10 @@ go.etcd.io/etcd/raft/v3 v3.5.0/go.mod h1:UFOHSIvO/nKwd4lhkwabrTD3cqW5yVyYYf/KlD0
 go.etcd.io/etcd/server/v3 v3.5.0/go.mod h1:3Ah5ruV+M+7RZr0+Y/5mNLwC+eQlni+mQmOVdCRJoS4=
 go.mongodb.org/mongo-driver v1.7.0/go.mod h1:Q4oFMbo1+MSNqICAdYMlC/zSTrwCogR4R8NzkI+yfU8=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
-go.nhat.io/testcontainers-extra v0.10.0 h1:q+31CR5qr3o9kIoa+/OS+K3eKlRk/gZKT+FXlR5WSi0=
-go.nhat.io/testcontainers-extra v0.10.0/go.mod h1:FuvyYRg1OTYbNM9fqfq6RwBEYS14/t0vPo8uDonasNs=
-go.nhat.io/testcontainers-registry v0.12.0 h1:HteE/bqtayK2Hj1yUtD7HnrAoY/AE3NRlsGDFYaVKUM=
-go.nhat.io/testcontainers-registry v0.12.0/go.mod h1:hyXHu+zaYJZGK9u3itEA172SroknZWMTuJOgSn5oLSc=
+go.nhat.io/testcontainers-extra v0.11.0 h1:G7OvKyC8tsloR2mJ/t/ZdgYwcf7WcJ2u72+Jgicau8c=
+go.nhat.io/testcontainers-extra v0.11.0/go.mod h1:YUKNSvEerBtzYSPnCdC+IJcJ9vDYd5Ww8Ge/Ikt/jCA=
+go.nhat.io/testcontainers-registry v0.13.0 h1:lrCgEwsCpWzroCyPPnTNAqnrnRlcIdBUB+pAzljZnpw=
+go.nhat.io/testcontainers-registry v0.13.0/go.mod h1:U4DdP3LAZ26cvwIEqzgGNV6PR3uSldR3jC0q3ViEUGI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/postgres/go.mod
+++ b/postgres/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/jackc/pgx/v4 v4.18.1
 	github.com/stretchr/testify v1.8.2
-	go.nhat.io/testcontainers-extra v0.10.0
-	go.nhat.io/testcontainers-registry v0.12.0
+	go.nhat.io/testcontainers-extra v0.11.0
+	go.nhat.io/testcontainers-registry v0.13.0
 )
 
 require (

--- a/postgres/go.sum
+++ b/postgres/go.sum
@@ -1148,10 +1148,10 @@ go.etcd.io/etcd/raft/v3 v3.5.0/go.mod h1:UFOHSIvO/nKwd4lhkwabrTD3cqW5yVyYYf/KlD0
 go.etcd.io/etcd/server/v3 v3.5.0/go.mod h1:3Ah5ruV+M+7RZr0+Y/5mNLwC+eQlni+mQmOVdCRJoS4=
 go.mongodb.org/mongo-driver v1.7.0/go.mod h1:Q4oFMbo1+MSNqICAdYMlC/zSTrwCogR4R8NzkI+yfU8=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
-go.nhat.io/testcontainers-extra v0.10.0 h1:q+31CR5qr3o9kIoa+/OS+K3eKlRk/gZKT+FXlR5WSi0=
-go.nhat.io/testcontainers-extra v0.10.0/go.mod h1:FuvyYRg1OTYbNM9fqfq6RwBEYS14/t0vPo8uDonasNs=
-go.nhat.io/testcontainers-registry v0.12.0 h1:HteE/bqtayK2Hj1yUtD7HnrAoY/AE3NRlsGDFYaVKUM=
-go.nhat.io/testcontainers-registry v0.12.0/go.mod h1:hyXHu+zaYJZGK9u3itEA172SroknZWMTuJOgSn5oLSc=
+go.nhat.io/testcontainers-extra v0.11.0 h1:G7OvKyC8tsloR2mJ/t/ZdgYwcf7WcJ2u72+Jgicau8c=
+go.nhat.io/testcontainers-extra v0.11.0/go.mod h1:YUKNSvEerBtzYSPnCdC+IJcJ9vDYd5Ww8Ge/Ikt/jCA=
+go.nhat.io/testcontainers-registry v0.13.0 h1:lrCgEwsCpWzroCyPPnTNAqnrnRlcIdBUB+pAzljZnpw=
+go.nhat.io/testcontainers-registry v0.13.0/go.mod h1:U4DdP3LAZ26cvwIEqzgGNV6PR3uSldR3jC0q3ViEUGI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
## Description

Bump go.nhat.io/testcontainers-extra to v0.11.0