### PR TITLE
Bump `go.nhat.io/testcontainers-extra` to `v0.15.0`

### DIFF
--- a/elasticsearch/go.mod
+++ b/elasticsearch/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/docker/docker v27.2.1+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/stretchr/testify v1.9.0
-	go.nhat.io/testcontainers-extra v0.14.0
+	go.nhat.io/testcontainers-extra v0.15.0
 )
 
 require (

--- a/elasticsearch/go.sum
+++ b/elasticsearch/go.sum
@@ -110,8 +110,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-go.nhat.io/testcontainers-extra v0.14.0 h1:pGBqazB5I2OOhXgjNrKEiXTzjjLReY9FPSLcYUrkYXY=
-go.nhat.io/testcontainers-extra v0.14.0/go.mod h1:e8uciPE6t4eihgNp6J4NwEJKkYMBIwCPEvwHyjdvAlw=
+go.nhat.io/testcontainers-extra v0.15.0 h1:FUHkiPi1fiKLrDgpnzY1KC6y24ls9XfCGY0A5kLMeUI=
+go.nhat.io/testcontainers-extra v0.15.0/go.mod h1:Rvp+2hSGazWRmXzJzM1oeYKQXNAhXomE6iFnB8gp3T8=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.55.0 h1:ZIg3ZT/aQ7AfKqdwp7ECpOK6vHqquXXuyTjIO8ZdmPs=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.55.0/go.mod h1:DQAwmETtZV00skUwgD6+0U89g80NKsJE3DCKeLLPQMI=
 go.opentelemetry.io/otel v1.30.0 h1:F2t8sK4qf1fAmY9ua4ohFS/K+FUuOPemHUIXHtktrts=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 require (
 	github.com/golang-migrate/migrate/v4 v4.18.1
-	go.nhat.io/testcontainers-extra v0.14.0
+	go.nhat.io/testcontainers-extra v0.15.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-go.nhat.io/testcontainers-extra v0.14.0 h1:pGBqazB5I2OOhXgjNrKEiXTzjjLReY9FPSLcYUrkYXY=
-go.nhat.io/testcontainers-extra v0.14.0/go.mod h1:e8uciPE6t4eihgNp6J4NwEJKkYMBIwCPEvwHyjdvAlw=
+go.nhat.io/testcontainers-extra v0.15.0 h1:FUHkiPi1fiKLrDgpnzY1KC6y24ls9XfCGY0A5kLMeUI=
+go.nhat.io/testcontainers-extra v0.15.0/go.mod h1:Rvp+2hSGazWRmXzJzM1oeYKQXNAhXomE6iFnB8gp3T8=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.55.0 h1:ZIg3ZT/aQ7AfKqdwp7ECpOK6vHqquXXuyTjIO8ZdmPs=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.55.0/go.mod h1:DQAwmETtZV00skUwgD6+0U89g80NKsJE3DCKeLLPQMI=
 go.opentelemetry.io/otel v1.30.0 h1:F2t8sK4qf1fAmY9ua4ohFS/K+FUuOPemHUIXHtktrts=

--- a/mongo/go.mod
+++ b/mongo/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.18.1
 	github.com/stretchr/testify v1.9.0
 	go.mongodb.org/mongo-driver v1.16.1
-	go.nhat.io/testcontainers-extra v0.14.0
+	go.nhat.io/testcontainers-extra v0.15.0
 	go.nhat.io/testcontainers-registry v0.16.0
 )
 

--- a/mongo/go.sum
+++ b/mongo/go.sum
@@ -136,8 +136,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.mongodb.org/mongo-driver v1.16.1 h1:rIVLL3q0IHM39dvE+z2ulZLp9ENZKThVfuvN/IiN4l8=
 go.mongodb.org/mongo-driver v1.16.1/go.mod h1:oB6AhJQvFQL4LEHyXi6aJzQJtBiTQHiAd83l0GdFaiw=
-go.nhat.io/testcontainers-extra v0.14.0 h1:pGBqazB5I2OOhXgjNrKEiXTzjjLReY9FPSLcYUrkYXY=
-go.nhat.io/testcontainers-extra v0.14.0/go.mod h1:e8uciPE6t4eihgNp6J4NwEJKkYMBIwCPEvwHyjdvAlw=
+go.nhat.io/testcontainers-extra v0.15.0 h1:FUHkiPi1fiKLrDgpnzY1KC6y24ls9XfCGY0A5kLMeUI=
+go.nhat.io/testcontainers-extra v0.15.0/go.mod h1:Rvp+2hSGazWRmXzJzM1oeYKQXNAhXomE6iFnB8gp3T8=
 go.nhat.io/testcontainers-registry v0.16.0 h1:aJe/coeB4B4ug/lS77265kvxGYnilTTIYKvoCxUwxUU=
 go.nhat.io/testcontainers-registry v0.16.0/go.mod h1:5lZHOIPgzcYhAS0zmob8xF+mmXyHFBqTcnzThnRhgKc=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.55.0 h1:ZIg3ZT/aQ7AfKqdwp7ECpOK6vHqquXXuyTjIO8ZdmPs=

--- a/mssql/go.mod
+++ b/mssql/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.18.1
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.33.0
-	go.nhat.io/testcontainers-extra v0.14.0
+	go.nhat.io/testcontainers-extra v0.15.0
 	go.nhat.io/testcontainers-registry v0.16.0
 )
 

--- a/mssql/go.sum
+++ b/mssql/go.sum
@@ -165,8 +165,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-go.nhat.io/testcontainers-extra v0.14.0 h1:pGBqazB5I2OOhXgjNrKEiXTzjjLReY9FPSLcYUrkYXY=
-go.nhat.io/testcontainers-extra v0.14.0/go.mod h1:e8uciPE6t4eihgNp6J4NwEJKkYMBIwCPEvwHyjdvAlw=
+go.nhat.io/testcontainers-extra v0.15.0 h1:FUHkiPi1fiKLrDgpnzY1KC6y24ls9XfCGY0A5kLMeUI=
+go.nhat.io/testcontainers-extra v0.15.0/go.mod h1:Rvp+2hSGazWRmXzJzM1oeYKQXNAhXomE6iFnB8gp3T8=
 go.nhat.io/testcontainers-registry v0.16.0 h1:aJe/coeB4B4ug/lS77265kvxGYnilTTIYKvoCxUwxUU=
 go.nhat.io/testcontainers-registry v0.16.0/go.mod h1:5lZHOIPgzcYhAS0zmob8xF+mmXyHFBqTcnzThnRhgKc=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.55.0 h1:ZIg3ZT/aQ7AfKqdwp7ECpOK6vHqquXXuyTjIO8ZdmPs=

--- a/mysql/go.mod
+++ b/mysql/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.18.1
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.33.0
-	go.nhat.io/testcontainers-extra v0.14.0
+	go.nhat.io/testcontainers-extra v0.15.0
 	go.nhat.io/testcontainers-registry v0.16.0
 )
 

--- a/mysql/go.sum
+++ b/mysql/go.sum
@@ -125,8 +125,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-go.nhat.io/testcontainers-extra v0.14.0 h1:pGBqazB5I2OOhXgjNrKEiXTzjjLReY9FPSLcYUrkYXY=
-go.nhat.io/testcontainers-extra v0.14.0/go.mod h1:e8uciPE6t4eihgNp6J4NwEJKkYMBIwCPEvwHyjdvAlw=
+go.nhat.io/testcontainers-extra v0.15.0 h1:FUHkiPi1fiKLrDgpnzY1KC6y24ls9XfCGY0A5kLMeUI=
+go.nhat.io/testcontainers-extra v0.15.0/go.mod h1:Rvp+2hSGazWRmXzJzM1oeYKQXNAhXomE6iFnB8gp3T8=
 go.nhat.io/testcontainers-registry v0.16.0 h1:aJe/coeB4B4ug/lS77265kvxGYnilTTIYKvoCxUwxUU=
 go.nhat.io/testcontainers-registry v0.16.0/go.mod h1:5lZHOIPgzcYhAS0zmob8xF+mmXyHFBqTcnzThnRhgKc=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.55.0 h1:ZIg3ZT/aQ7AfKqdwp7ECpOK6vHqquXXuyTjIO8ZdmPs=

--- a/postgres/go.mod
+++ b/postgres/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.18.1
 	github.com/jackc/pgx/v4 v4.18.3
 	github.com/stretchr/testify v1.9.0
-	go.nhat.io/testcontainers-extra v0.14.0
+	go.nhat.io/testcontainers-extra v0.15.0
 	go.nhat.io/testcontainers-registry v0.16.0
 )
 

--- a/postgres/go.sum
+++ b/postgres/go.sum
@@ -216,8 +216,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
-go.nhat.io/testcontainers-extra v0.14.0 h1:pGBqazB5I2OOhXgjNrKEiXTzjjLReY9FPSLcYUrkYXY=
-go.nhat.io/testcontainers-extra v0.14.0/go.mod h1:e8uciPE6t4eihgNp6J4NwEJKkYMBIwCPEvwHyjdvAlw=
+go.nhat.io/testcontainers-extra v0.15.0 h1:FUHkiPi1fiKLrDgpnzY1KC6y24ls9XfCGY0A5kLMeUI=
+go.nhat.io/testcontainers-extra v0.15.0/go.mod h1:Rvp+2hSGazWRmXzJzM1oeYKQXNAhXomE6iFnB8gp3T8=
 go.nhat.io/testcontainers-registry v0.16.0 h1:aJe/coeB4B4ug/lS77265kvxGYnilTTIYKvoCxUwxUU=
 go.nhat.io/testcontainers-registry v0.16.0/go.mod h1:5lZHOIPgzcYhAS0zmob8xF+mmXyHFBqTcnzThnRhgKc=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.55.0 h1:ZIg3ZT/aQ7AfKqdwp7ECpOK6vHqquXXuyTjIO8ZdmPs=


### PR DESCRIPTION
## Description

Bump `go.nhat.io/testcontainers-extra` to `v0.15.0`